### PR TITLE
Remove hardcoded connection name

### DIFF
--- a/Bridge/Doctrine/AclFilter.php
+++ b/Bridge/Doctrine/AclFilter.php
@@ -71,7 +71,7 @@ class AclFilter
     {
         $this->em = $doctrine->getManager();
         $this->tokenStorage = $tokenStorage;
-        $this->aclConnection = $doctrine->getConnection('default');
+        $this->aclConnection = $doctrine->getConnection();
         $this->aclWalker = $aclWalker;
         $this->roleHierarchy = $roleHierarchy;
     }


### PR DESCRIPTION
This patch fixes an issue that prevents the ACL filter from using a different db connection than 'default' fx. in tests.